### PR TITLE
Added non-default composer vendor dir detection 

### DIFF
--- a/bin/crook
+++ b/bin/crook
@@ -2,13 +2,20 @@
 
 <?php
 
+function defineComposerVendorDir()
+{
+    $vendorDir = exec('composer config vendor-dir');
+
+    define('CROOK_COMPOSER_VENDOR_DIR', $vendorDir);
+}
+
 function defineComposerAutoloadPath()
 {
     $autoload = [
         __DIR__ . '/../../../autoload.php',
         __DIR__ . '/../../autoload.php',
-        __DIR__ . '/../vendor/autoload.php',
-        __DIR__ . '/vendor/autoload.php'
+        __DIR__ . '/../' . CROOK_COMPOSER_VENDOR_DIR . '/autoload.php',
+        __DIR__ . '/' . CROOK_COMPOSER_VENDOR_DIR . '/autoload.php'
     ];
 
     foreach ($autoload as $file) {
@@ -35,7 +42,7 @@ function defineProjectRootPath()
 {
     $rootDir = __DIR__ . '/../../../../';
 
-    if (file_exists($rootDir . '/vendor')) {
+    if (file_exists($rootDir . '/' . CROOK_COMPOSER_VENDOR_DIR)) {
         define('CROOK_PROJECT_ROOT', $rootDir);
     }
 }
@@ -43,9 +50,9 @@ function defineProjectRootPath()
 $crookName = 'Crook';
 $crookVersion = '0.0.1';
 
+defineComposerVendorDir();
 defineComposerAutoloadPath();
 defineProjectRootPath();
-
 
 require_once CROOK_COMPOSER_AUTOLOAD;
 

--- a/src/crook/Config.php
+++ b/src/crook/Config.php
@@ -35,7 +35,7 @@ class Config
      */
     public function getVendorDir()
     {
-        return $this->getProjectRoot() . 'vendor/';
+        return $this->getProjectRoot() . CROOK_COMPOSER_VENDOR_DIR . '/';
     }
 
     /**

--- a/theHook
+++ b/theHook
@@ -2,7 +2,13 @@
 
 <?php
 
-require_once 'vendor/autoload.php';
+if (!defined('CROOK_COMPOSER_VENDOR_DIR')) {
+    $vendorDir = exec('composer config vendor-dir');
+
+    define('CROOK_COMPOSER_VENDOR_DIR', $vendorDir);
+}
+
+require_once CROOK_COMPOSER_VENDOR_DIR . '/autoload.php';
 
 if (!defined('CROOK_PROJECT_ROOT')) {
     define('CROOK_PROJECT_ROOT', __DIR__ . '/');


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| What?         | Added non-default composer vendor directory detection 
| Why?          | To enable the using of non-default composer vendor directory, setted by the **config/vendor-dir** on composer.json file.
| How?          | Using composer itself to get the used vendor directory, running the command **composer config vendor-dir**.